### PR TITLE
Make CEN type safe

### DIFF
--- a/app/src/main/java/org/coepi/android/ble/BleModule.kt
+++ b/app/src/main/java/org/coepi/android/ble/BleModule.kt
@@ -6,6 +6,7 @@ import org.coepi.android.ble.covidwatch.BLEAdvertiser
 import org.coepi.android.ble.covidwatch.BLEAdvertiserImpl
 import org.coepi.android.ble.covidwatch.BLEScanner
 import org.coepi.android.ble.covidwatch.BLEScannerImpl
+import org.coepi.android.cen.Cen
 import org.koin.android.ext.koin.androidApplication
 import org.koin.dsl.module
 import java.util.UUID
@@ -35,14 +36,14 @@ private fun createBleScanner(app: Application): BLEScanner =
     } ?: NoopBleScanner()
 
 class NoopBleAdvertiser: BLEAdvertiser {
-    override fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, value: String) {}
+    override fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, cen: Cen) {}
     override fun stopAdvertiser() {}
-    override fun changeAdvertisedValue(value: String) {}
-    override fun registerWriteCallback(callback: (String) -> Unit) {}
+    override fun changeAdvertisedValue(cen: Cen) {}
+    override fun registerWriteCallback(callback: (Cen) -> Unit) {}
 }
 
 class NoopBleScanner: BLEScanner {
     override fun startScanning(serviceUUIDs: Array<UUID>) {}
-    override fun registerScanCallback(callback: (String) -> Unit) {}
+    override fun registerScanCallback(callback: (Cen) -> Unit) {}
     override fun stopScanning() {}
 }

--- a/app/src/main/java/org/coepi/android/ble/BleModule.kt
+++ b/app/src/main/java/org/coepi/android/ble/BleModule.kt
@@ -35,14 +35,14 @@ private fun createBleScanner(app: Application): BLEScanner =
     } ?: NoopBleScanner()
 
 class NoopBleAdvertiser: BLEAdvertiser {
-    override fun startAdvertiser(serviceUUID: UUID?, characteristicUUID: UUID?, value: String?) {}
+    override fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, value: String) {}
     override fun stopAdvertiser() {}
-    override fun changeAdvertisedValue(value: String?) {}
+    override fun changeAdvertisedValue(value: String) {}
     override fun registerWriteCallback(callback: (String) -> Unit) {}
 }
 
 class NoopBleScanner: BLEScanner {
-    override fun startScanning(serviceUUIDs: Array<UUID>?) {}
+    override fun startScanning(serviceUUIDs: Array<UUID>) {}
     override fun registerScanCallback(callback: (String) -> Unit) {}
     override fun stopScanning() {}
 }

--- a/app/src/main/java/org/coepi/android/ble/BleSimulator.kt
+++ b/app/src/main/java/org/coepi/android/ble/BleSimulator.kt
@@ -3,19 +3,21 @@ package org.coepi.android.ble
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
+import org.coepi.android.ble.covidwatch.utils.toBytes
+import org.coepi.android.cen.Cen
 import java.util.UUID
 import java.util.concurrent.TimeUnit.SECONDS
 
 class BleSimulator : BleManager {
-    override val scanObservable: Observable<String> =
+    override val scanObservable: Observable<Cen> =
         Observable.interval(0, 5, SECONDS)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .map { UUID.randomUUID().toString() } // TODO CEN
+            .map { Cen(UUID.randomUUID().toBytes()) }
 
-    override fun startAdvertiser(value: String) {}
+    override fun startAdvertiser(cen: Cen) {}
     override fun stopAdvertiser() {}
-    override fun startService(value: String) {}
+    override fun startService(cen: Cen) {}
     override fun stopService() {}
-    override fun changeAdvertisedValue(value: String) {}
+    override fun changeAdvertisedValue(cen: Cen) {}
 }

--- a/app/src/main/java/org/coepi/android/ble/covidwatch/BLEAdvertiser.kt
+++ b/app/src/main/java/org/coepi/android/ble/covidwatch/BLEAdvertiser.kt
@@ -15,12 +15,13 @@ import android.bluetooth.le.BluetoothLeAdvertiser
 import android.content.Context
 import android.os.ParcelUuid
 import android.util.Log
+import org.coepi.android.system.log.log
 import java.util.UUID
 
 interface BLEAdvertiser {
-    fun startAdvertiser(serviceUUID: UUID?, characteristicUUID: UUID?, value: String?)
+    fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, value: String)
     fun stopAdvertiser()
-    fun changeAdvertisedValue(value: String?)
+    fun changeAdvertisedValue(value: String)
     fun registerWriteCallback(callback: (String) -> Unit)
 }
 
@@ -138,12 +139,12 @@ class BLEAdvertiserImpl(private val context: Context, adapter: BluetoothAdapter)
      * ADVERTISE_MODE_LOW_LATENCY is a must as the other nodes are not real-time.
      *
      * @param serviceUUID The UUID to advertise the service
-     * @param contactEventUUID The UUID that indicates the contact event
+     * @param characteristicUUID The UUID that indicates the contact event
      */
     override fun startAdvertiser(
-        serviceUUID: UUID?,
-        characteristicUUID: UUID?,
-        value: String?
+        serviceUUID: UUID,
+        characteristicUUID: UUID,
+        value: String
     ) {
         this.serviceUUID = serviceUUID
         this.characteristicUUID = characteristicUUID
@@ -203,8 +204,13 @@ class BLEAdvertiserImpl(private val context: Context, adapter: BluetoothAdapter)
      * Changes the CEI to a new UUID in the service data field
      * NOTE: This will also stop/start the advertiser
      */
-    override fun changeAdvertisedValue(value: String?) {
+    override fun changeAdvertisedValue(value: String) {
+        val serviceUUID = serviceUUID ?: log.e("No service configured").run { return }
+        val characteristicUUID =
+            characteristicUUID ?: log.e("No characteristic configured").run { return }
+
         Log.i(TAG, "Changing the contact event identifier in service data field...")
+
         stopAdvertiser()
         startAdvertiser(serviceUUID, characteristicUUID, value)
     }

--- a/app/src/main/java/org/coepi/android/ble/covidwatch/BLEAdvertiser.kt
+++ b/app/src/main/java/org/coepi/android/ble/covidwatch/BLEAdvertiser.kt
@@ -15,14 +15,15 @@ import android.bluetooth.le.BluetoothLeAdvertiser
 import android.content.Context
 import android.os.ParcelUuid
 import android.util.Log
+import org.coepi.android.cen.Cen
 import org.coepi.android.system.log.log
 import java.util.UUID
 
 interface BLEAdvertiser {
-    fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, value: String)
+    fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, cen: Cen)
     fun stopAdvertiser()
-    fun changeAdvertisedValue(value: String)
-    fun registerWriteCallback(callback: (String) -> Unit)
+    fun changeAdvertisedValue(cen: Cen)
+    fun registerWriteCallback(callback: (Cen) -> Unit)
 }
 
 /**
@@ -41,11 +42,11 @@ class BLEAdvertiserImpl(private val context: Context, adapter: BluetoothAdapter)
     private var serviceUUID: UUID? = null
     private var characteristicUUID: UUID? = null
 
-    private var advertisedValue: String? = null
+    private var advertisedCen: Cen? = null
 
     // Case Android (Central) - iOS (Peripheral)
     // https://docs.google.com/document/d/1f65V3PI214-uYfZLUZtm55kdVwoazIMqGJrxcYNI4eg/edit#
-    private var writeCallback: ((String) -> Unit)? = null
+    private var writeCallback: ((Cen) -> Unit)? = null
 
     // CONSTANTS
     companion object {
@@ -103,12 +104,11 @@ class BLEAdvertiserImpl(private val context: Context, adapter: BluetoothAdapter)
                             return
                         }
 
-                        val str = value?.let { String(it) }
-                        if (str == null) {
+                        if (value == null) {
                             result = BluetoothGatt.GATT_FAILURE
                             return
                         }
-                        writeCallback?.invoke(str)
+                        writeCallback?.invoke(Cen(value))
 
                     } else {
                         result = BluetoothGatt.GATT_FAILURE
@@ -144,11 +144,11 @@ class BLEAdvertiserImpl(private val context: Context, adapter: BluetoothAdapter)
     override fun startAdvertiser(
         serviceUUID: UUID,
         characteristicUUID: UUID,
-        value: String
+        cen: Cen
     ) {
         this.serviceUUID = serviceUUID
         this.characteristicUUID = characteristicUUID
-        advertisedValue = value
+        advertisedCen = cen
 
         val settings = AdvertiseSettings.Builder()
             .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
@@ -156,13 +156,10 @@ class BLEAdvertiserImpl(private val context: Context, adapter: BluetoothAdapter)
             .setConnectable(true)
             .build()
 
-        // TODO review this
-        val advertisedValueBytes = advertisedValue?.toByteArray()
-
 //        val testServiceDataMaxLength = ByteArray(20)
         val data = AdvertiseData.Builder()
             .setIncludeDeviceName(false)
-            .addServiceData(ParcelUuid(serviceUUID), advertisedValueBytes)
+            .addServiceData(ParcelUuid(serviceUUID), cen.bytes)
 //            .addServiceData(ParcelUuid(serviceUUID), testServiceDataMaxLength)
             .build()
 
@@ -204,7 +201,7 @@ class BLEAdvertiserImpl(private val context: Context, adapter: BluetoothAdapter)
      * Changes the CEI to a new UUID in the service data field
      * NOTE: This will also stop/start the advertiser
      */
-    override fun changeAdvertisedValue(value: String) {
+    override fun changeAdvertisedValue(cen: Cen) {
         val serviceUUID = serviceUUID ?: log.e("No service configured").run { return }
         val characteristicUUID =
             characteristicUUID ?: log.e("No characteristic configured").run { return }
@@ -212,10 +209,10 @@ class BLEAdvertiserImpl(private val context: Context, adapter: BluetoothAdapter)
         Log.i(TAG, "Changing the contact event identifier in service data field...")
 
         stopAdvertiser()
-        startAdvertiser(serviceUUID, characteristicUUID, value)
+        startAdvertiser(serviceUUID, characteristicUUID, cen)
     }
 
-    override fun registerWriteCallback(callback: (String) -> Unit) {
+    override fun registerWriteCallback(callback: (Cen) -> Unit) {
         writeCallback = callback
     }
 }

--- a/app/src/main/java/org/coepi/android/ble/covidwatch/BLEForegroundService.kt
+++ b/app/src/main/java/org/coepi/android/ble/covidwatch/BLEForegroundService.kt
@@ -12,6 +12,7 @@ import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LifecycleService
 import org.coepi.android.MainActivity
 import org.coepi.android.R
+import org.coepi.android.cen.Cen
 import org.coepi.android.system.log.log
 import java.util.Timer
 import java.util.UUID
@@ -19,21 +20,21 @@ import java.util.UUID
 interface BleService {
     fun configure(configuration: BleServiceConfiguration)
 
-    fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, value: String)
+    fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, cen: Cen)
     fun stopAdvertiser()
-    fun registerAdvertiserWriteCallback(callback: (String) -> Unit)
+    fun registerAdvertiserWriteCallback(callback: (Cen) -> Unit)
 
-    fun changeAdvertisedValue(value: String)
+    fun changeAdvertisedCen(cen: Cen)
 }
 
 data class BleServiceConfiguration(
     val serviceUUID: UUID,
     val characteristicUUID: UUID,
-    val startValue: String,
+    val startCen: Cen,
     val advertiser: BLEAdvertiser,
     val scanner: BLEScanner,
-    val scanCallback: (String) -> Unit,
-    val advertiserWriteCallback: (String) -> Unit
+    val scanCallback: (Cen) -> Unit,
+    val advertiserWriteCallback: (Cen) -> Unit
 )
 
 class BLEForegroundService : LifecycleService(), BleService {
@@ -93,15 +94,15 @@ class BLEForegroundService : LifecycleService(), BleService {
     }
 
 
-    override fun changeAdvertisedValue(value: String) {
+    override fun changeAdvertisedCen(cen: Cen) {
         val configuration = configuration ?: run {
             log.e("Changing contact identifier but not configured yet")
             return
         }
-        configuration.advertiser.changeAdvertisedValue(value)
+        configuration.advertiser.changeAdvertisedValue(cen)
     }
 
-    override fun registerAdvertiserWriteCallback(callback: (String) -> Unit) {
+    override fun registerAdvertiserWriteCallback(callback: (Cen) -> Unit) {
         val configuration = configuration ?: error("Not configured")
         configuration.advertiser.registerWriteCallback(callback)
     }
@@ -138,13 +139,13 @@ class BLEForegroundService : LifecycleService(), BleService {
 
     private fun BleServiceConfiguration.start() {
         advertiser.registerWriteCallback(advertiserWriteCallback)
-        advertiser.startAdvertiser(serviceUUID, characteristicUUID, startValue)
+        advertiser.startAdvertiser(serviceUUID, characteristicUUID, startCen)
         scanner.registerScanCallback(scanCallback)
         scanner.startScanning(arrayOf(serviceUUID))
     }
 
-    override fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, value: String) {
-        configuration?.advertiser?.startAdvertiser(serviceUUID, characteristicUUID, value)
+    override fun startAdvertiser(serviceUUID: UUID, characteristicUUID: UUID, cen: Cen) {
+        configuration?.advertiser?.startAdvertiser(serviceUUID, characteristicUUID, cen)
     }
 
     override fun stopAdvertiser() {

--- a/app/src/main/java/org/coepi/android/ble/covidwatch/BLEScanner.kt
+++ b/app/src/main/java/org/coepi/android/ble/covidwatch/BLEScanner.kt
@@ -12,19 +12,20 @@ import android.os.ParcelUuid
 import android.util.Log
 import androidx.annotation.RequiresApi
 import org.coepi.android.ble.covidwatch.utils.toUUID
+import org.coepi.android.cen.Cen
 import java.util.UUID
 
 interface BLEScanner {
     fun startScanning(serviceUUIDs: Array<UUID>)
 
-    fun registerScanCallback(callback: (String) -> Unit)
+    fun registerScanCallback(callback: (Cen) -> Unit)
 
     fun stopScanning()
 }
 
 class BLEScannerImpl(ctx: Context, adapter: BluetoothAdapter): BLEScanner {
 
-    private var callback: ((String) -> Unit)? = null
+    private var callback: ((Cen) -> Unit)? = null
 
     // TODO consider injecting UUID so it's not optional
     private var serviceUuid: UUID? = null
@@ -71,7 +72,7 @@ class BLEScannerImpl(ctx: Context, adapter: BluetoothAdapter): BLEScanner {
 
                 scanRecord.serviceUuids.filter { it.uuid == serviceUuid }.forEach { uuid ->
                     scanRecord.serviceData[uuid]?.let { bytes ->
-                        callback?.invoke(String(bytes))
+                        callback?.invoke(Cen(bytes))
                     }
                 }
             }
@@ -110,7 +111,7 @@ class BLEScannerImpl(ctx: Context, adapter: BluetoothAdapter): BLEScanner {
         Log.i(TAG, "Started scanning")
     }
 
-    override fun registerScanCallback(callback: (String) -> Unit) {
+    override fun registerScanCallback(callback: (Cen) -> Unit) {
         this.callback = callback
     }
 

--- a/app/src/main/java/org/coepi/android/ble/covidwatch/BLEScanner.kt
+++ b/app/src/main/java/org/coepi/android/ble/covidwatch/BLEScanner.kt
@@ -15,7 +15,7 @@ import org.coepi.android.ble.covidwatch.utils.toUUID
 import java.util.UUID
 
 interface BLEScanner {
-    fun startScanning(serviceUUIDs: Array<UUID>?)
+    fun startScanning(serviceUUIDs: Array<UUID>)
 
     fun registerScanCallback(callback: (String) -> Unit)
 
@@ -84,11 +84,11 @@ class BLEScannerImpl(ctx: Context, adapter: BluetoothAdapter): BLEScanner {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
-    override fun startScanning(serviceUUIDs: Array<UUID>?) {
+    override fun startScanning(serviceUUIDs: Array<UUID>) {
 
         val scanner = scanner ?: return
 
-        val scanFilters = serviceUUIDs?.map {
+        val scanFilters = serviceUUIDs.map {
             ScanFilter.Builder().setServiceUuid(ParcelUuid(it)).build()
         }
 

--- a/app/src/main/java/org/coepi/android/cen/Cen.kt
+++ b/app/src/main/java/org/coepi/android/cen/Cen.kt
@@ -1,0 +1,3 @@
+package org.coepi.android.cen
+
+data class Cen(val bytes: ByteArray)

--- a/app/src/main/java/org/coepi/android/cen/Cen.kt
+++ b/app/src/main/java/org/coepi/android/cen/Cen.kt
@@ -1,3 +1,0 @@
-package org.coepi.android.cen
-
-data class Cen(val cen: String, val timestamp: Int)

--- a/app/src/main/java/org/coepi/android/cen/CenManager.kt
+++ b/app/src/main/java/org/coepi/android/cen/CenManager.kt
@@ -25,11 +25,11 @@ class CenManager(
         disposables += Observables.combineLatest(
             blePreconditions.bleEnabled,
             // Take the first CEN, needed to start the service
-            cenRepo.CEN
+            cenRepo.cen
         )
         .take(1)
         .subscribeBy(onNext = { (_, firstCen) ->
-            bleManager.startService(firstCen.toString()) // TODO review String <-> ByteArray
+            bleManager.startService(firstCen) // TODO review String <-> ByteArray
             log.i("BlePreconditions met - BLE manager started")
         }, onError = {
             log.i("Error enabling bluetooth: $it")
@@ -40,9 +40,8 @@ class CenManager(
      * Sends CEN to advertiser when it's changed in DB
      */
     private fun observeCen() {
-        disposables += cenRepo.CEN.subscribeBy (onNext = { cen ->
+        disposables += cenRepo.cen.subscribeBy (onNext = { cen ->
             // ServiceData holds Android Contact Event Number (CEN) that the Android peripheral is advertising
-            val cenString = cen.toString()
 
             // TODO is check really needed? If yes, either add flag to advertiser or expose state and use here
 //            if (started) {
@@ -50,7 +49,7 @@ class CenManager(
 //            }
 
             if (cen != null) {
-                bleManager.startAdvertiser(cenString)
+                bleManager.startAdvertiser(cen)
             }
         }, onError = {
             log.i("Error observing CEN: $it")

--- a/app/src/main/java/org/coepi/android/cen/CenManager.kt
+++ b/app/src/main/java/org/coepi/android/cen/CenManager.kt
@@ -29,7 +29,7 @@ class CenManager(
         )
         .take(1)
         .subscribeBy(onNext = { (_, firstCen) ->
-            bleManager.startService(firstCen) // TODO review String <-> ByteArray
+            bleManager.startService(firstCen)
             log.i("BlePreconditions met - BLE manager started")
         }, onError = {
             log.i("Error enabling bluetooth: $it")

--- a/app/src/main/java/org/coepi/android/cen/CenRepo.kt
+++ b/app/src/main/java/org/coepi/android/cen/CenRepo.kt
@@ -23,7 +23,7 @@ class CenRepo(private val cenApi: CENApi, private val cenDao: RealmCenDao, priva
     private var cenKeyTimestamp = 0
     
     // the latest CEN (ByteArray form), generated using cenKey
-    var cen : BehaviorSubject<Cen> = create()
+    val cen : BehaviorSubject<Cen> = create()
     private var CENKeyLifetimeInSeconds = 7*86400 // every 7 days a new key is generated
     var CENLifetimeInSeconds = 15*60   // every 15 mins a new CEN is generated
     private val periodicCENKeysCheckFrequencyInSeconds = 60*30 // run every 30 mins

--- a/app/src/main/java/org/coepi/android/cen/CenRepo.kt
+++ b/app/src/main/java/org/coepi/android/cen/CenRepo.kt
@@ -1,14 +1,12 @@
 package org.coepi.android.cen
 
 import android.os.Handler
-import android.util.Log
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.BehaviorSubject.create
 import org.coepi.android.system.log.log
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import java.util.Base64
 import java.util.Vector
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
@@ -90,7 +88,7 @@ class CenRepo(private val cenApi: CENApi, private val cenDao: RealmCenDao, priva
 
     // when a peripheral CEN is detected through BLE, it is recorded here
     fun insertCEN(CEN: String) {
-        val c = Cen(
+        val c = ReceivedCen(
             CEN,
             (System.currentTimeMillis() / 1000L).toInt()
         )
@@ -182,7 +180,7 @@ class CenRepo(private val cenApi: CENApi, private val cenDao: RealmCenDao, priva
 
     // matchCENKey uses a publicized key and finds matches with one database call per key
     //  Not efficient... It would be best if all observed CENs are loaded into memory
-    fun matchCENKey(key : String, maxTimestamp : Int) : List<RealmCen>? {
+    fun matchCENKey(key : String, maxTimestamp : Int) : List<RealmReceivedCen>? {
         // take the last 7 days of timestamps and generate all the possible CENs (e.g. 7 days) TODO: Parallelize this?
         val minTimestamp = maxTimestamp - 7*24* 60
         var possibleCENs = Array<String>(7*24 *(60/CENLifetimeInSeconds)) {i ->

--- a/app/src/main/java/org/coepi/android/cen/RealmCenDao.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmCenDao.kt
@@ -8,11 +8,11 @@ import org.coepi.android.repo.RealmProvider
 class RealmCenDao(private val realmProvider: RealmProvider) {
     private val realm get() = realmProvider.realm
 
-    fun all(): List<RealmCen> =
-        realm.where<RealmCen>().findAll()
+    fun all(): List<RealmReceivedCen> =
+        realm.where<RealmReceivedCen>().findAll()
 
-    fun matchCENs(start: Int, end: Int, cens: Array<String>): List<RealmCen> =
-        realm.where<RealmCen>()
+    fun matchCENs(start: Int, end: Int, cens: Array<String>): List<RealmReceivedCen> =
+        realm.where<RealmReceivedCen>()
             .greaterThanOrEqualTo("timestamp", start)
             .and()
             .lessThanOrEqualTo("timestamp", end)
@@ -20,9 +20,9 @@ class RealmCenDao(private val realmProvider: RealmProvider) {
             .oneOf("cen", cens)
             .findAll()
 
-    fun insert(cen: Cen) {
+    fun insert(cen: ReceivedCen) {
         realm.executeTransaction {
-            val realmObj = realm.createObject<RealmCen>() // Create a new object
+            val realmObj = realm.createObject<RealmReceivedCen>() // Create a new object
             realmObj.cen = cen.cen
             realmObj.timestamp = cen.timestamp
         }

--- a/app/src/main/java/org/coepi/android/cen/RealmCenDao.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmCenDao.kt
@@ -23,7 +23,7 @@ class RealmCenDao(private val realmProvider: RealmProvider) {
     fun insert(cen: ReceivedCen) {
         realm.executeTransaction {
             val realmObj = realm.createObject<RealmReceivedCen>() // Create a new object
-            realmObj.cen = cen.cen
+            realmObj.cen = cen.cen.bytes
             realmObj.timestamp = cen.timestamp
         }
     }

--- a/app/src/main/java/org/coepi/android/cen/RealmReceivedCen.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmReceivedCen.kt
@@ -3,6 +3,6 @@ package org.coepi.android.cen
 import io.realm.RealmObject
 
 open class RealmReceivedCen(
-    var cen: String = "",
+    var cen: ByteArray = ByteArray(0),
     var timestamp: Int = 0
 ): RealmObject()

--- a/app/src/main/java/org/coepi/android/cen/RealmReceivedCen.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmReceivedCen.kt
@@ -2,7 +2,7 @@ package org.coepi.android.cen
 
 import io.realm.RealmObject
 
-open class RealmCen(
+open class RealmReceivedCen(
     var cen: String = "",
     var timestamp: Int = 0
 ): RealmObject()

--- a/app/src/main/java/org/coepi/android/cen/ReceivedCen.kt
+++ b/app/src/main/java/org/coepi/android/cen/ReceivedCen.kt
@@ -1,0 +1,3 @@
+package org.coepi.android.cen
+
+data class ReceivedCen(val cen: String, val timestamp: Int)

--- a/app/src/main/java/org/coepi/android/cen/ReceivedCen.kt
+++ b/app/src/main/java/org/coepi/android/cen/ReceivedCen.kt
@@ -1,3 +1,3 @@
 package org.coepi.android.cen
 
-data class ReceivedCen(val cen: String, val timestamp: Int)
+data class ReceivedCen(val cen: Cen, val timestamp: Int)

--- a/app/src/main/java/org/coepi/android/ui/cen/CENRecyclerAdapter.kt
+++ b/app/src/main/java/org/coepi/android/ui/cen/CENRecyclerAdapter.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import org.coepi.android.R.layout.item_cen
-import org.coepi.android.cen.RealmCen
 import org.coepi.android.ui.cen.CENRecyclerViewAdapter.ViewHolder
 
 class CENRecyclerViewAdapter : RecyclerView.Adapter<ViewHolder>() {

--- a/app/src/main/java/org/coepi/android/ui/cen/CENViewModel.kt
+++ b/app/src/main/java/org/coepi/android/ui/cen/CENViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.MutableLiveData
 import org.coepi.android.ble.BleManager
+import org.coepi.android.cen.Cen
 import org.coepi.android.cen.CenRepo
 import org.coepi.android.cen.RealmCenReport
 import org.coepi.android.extensions.toLiveData
@@ -16,13 +17,16 @@ class CENViewModel(
 ) : ViewModel() {
 
     // CEN being broadcast by this device
-    val myCurrentCEN = repo.CEN
-        .map { "CEN: $it" }
+    val myCurrentCEN = repo.cen
+        .map { it.toString() }
         .toLiveData()
 
     // recently observed CENs
     val neighborCENs: LiveData<List<String>> = bleManager.scanObservable
-        .scan(emptyList<String>()) { acc, element -> acc + element }
+        .scan(emptyList<Cen>()) { acc, element -> acc + element }
+        .map { cens ->
+            cens.map { it.toString() }
+        }
         .toLiveData()
 
     // TODO

--- a/app/src/main/java/org/coepi/android/ui/cen/CENViewModel.kt
+++ b/app/src/main/java/org/coepi/android/ui/cen/CENViewModel.kt
@@ -3,10 +3,8 @@ package org.coepi.android.ui.cen
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Transformations
 import org.coepi.android.ble.BleManager
 import org.coepi.android.cen.CenRepo
-import org.coepi.android.cen.RealmCen
 import org.coepi.android.cen.RealmCenReport
 import org.coepi.android.extensions.toLiveData
 import org.coepi.android.ui.navigation.RootNavigation


### PR DESCRIPTION
- Renamed existing CEN (CEN+timestamp) into `ReceivedCen`, which reflects better our use case.
- Created new `Cen` type, to represent the "pure" CEN.
- `Cen` raw value is now always a byte array. No conversions to `String`, except to show in the UI.
- Removed some unnecessary parameter optionals.

If the spec is changed later, such that we need timestamps also for outgoing CENs, we can always change the types. The Realm type would require a migration, but this would be straight forward, especially if the app hasn't been released yet to the public (reinstall app).