### PR TITLE
Implement coepi repo

### DIFF
--- a/app/src/main/java/org/coepi/android/cen/CENApi.kt
+++ b/app/src/main/java/org/coepi/android/cen/CENApi.kt
@@ -1,5 +1,6 @@
 package org.coepi.android.cen
 
+import io.reactivex.Completable
 import io.reactivex.Single
 import retrofit2.Call
 import retrofit2.http.Body
@@ -10,7 +11,7 @@ import retrofit2.http.Path
 interface CENApi {
     // post CENReport along with CENKeys
     @POST("/cenreport")
-    fun postCENReport(@Body report : RealmCenReport): Single<Unit>
+    fun postCENReport(@Body report: CenReport): Completable
 
     // get recent keys that have CEN Reports
     @GET("/cenkeys/{timestamp}")
@@ -18,5 +19,5 @@ interface CENApi {
 
     // get report based on matched CENkey
     @GET("/cenreport/{key}")
-    fun getCENReport(@Path("key") key: String): Call<Array<RealmCenReport>>
+    fun getCenReport(@Path("key") key: String): Call<List<CenReport>>
 }

--- a/app/src/main/java/org/coepi/android/cen/CENModule.kt
+++ b/app/src/main/java/org/coepi/android/cen/CENModule.kt
@@ -1,11 +1,14 @@
 package org.coepi.android.cen
 
+import org.coepi.android.repo.CoEpiRepo
+import org.coepi.android.repo.CoepiRepoImpl
 import org.koin.dsl.module
 
 val CENModule = module {
     single { RealmCenDao(get()) }
     single { RealmCenReportDao(get()) }
     single { RealmCenKeyDao(get()) }
-    single { CenRepo(get(), get(), get(), get()) }
-    single { CenManager(get(), get(), get()) }
+    single<CenRepo> { CenRepoImpl(get(), get(), get(), get()) }
+    single<CoEpiRepo> { CoepiRepoImpl(get()) }
+    single { CenManager(get(), get(), get(), get()) }
 }

--- a/app/src/main/java/org/coepi/android/cen/CenManager.kt
+++ b/app/src/main/java/org/coepi/android/cen/CenManager.kt
@@ -6,26 +6,28 @@ import io.reactivex.rxkotlin.plusAssign
 import io.reactivex.rxkotlin.subscribeBy
 import org.coepi.android.ble.BleManager
 import org.coepi.android.ble.BlePreconditionsNotifier
+import org.coepi.android.repo.CoEpiRepo
 import org.coepi.android.system.log.log
 
 class CenManager(
     private val blePreconditions: BlePreconditionsNotifier,
     private val bleManager: BleManager,
-    private val cenRepo: CenRepo
+    private val cenRepo: CenRepo,
+    private val coepiRepo: CoEpiRepo
 ) {
     private val disposables = CompositeDisposable()
 
     fun start() {
-        initServiceWhenBleIsEnabled()
-        observeCen()
-        observeScanner()
+        startBleServiceWhenEnabled()
+        forwardRepoCenToBleAdvertiser()
+        observeScannedCens()
     }
 
-    private fun initServiceWhenBleIsEnabled() {
+    private fun startBleServiceWhenEnabled() {
         disposables += Observables.combineLatest(
             blePreconditions.bleEnabled,
             // Take the first CEN, needed to start the service
-            cenRepo.cen
+            cenRepo.generatedCen
         )
         .take(1)
         .subscribeBy(onNext = { (_, firstCen) ->
@@ -36,11 +38,8 @@ class CenManager(
         })
     }
 
-    /**
-     * Sends CEN to advertiser when it's changed in DB
-     */
-    private fun observeCen() {
-        disposables += cenRepo.cen.subscribeBy (onNext = { cen ->
+    private fun forwardRepoCenToBleAdvertiser() {
+        disposables += cenRepo.generatedCen.subscribeBy (onNext = { cen ->
             // ServiceData holds Android Contact Event Number (CEN) that the Android peripheral is advertising
 
             // TODO is check really needed? If yes, either add flag to advertiser or expose state and use here
@@ -48,18 +47,17 @@ class CenManager(
             bleManager.stopAdvertiser()
 //            }
 
-            if (cen != null) {
-                bleManager.startAdvertiser(cen)
-            }
+            bleManager.startAdvertiser(cen)
+
         }, onError = {
             log.i("Error observing CEN: $it")
         })
     }
 
-    private fun observeScanner() {
+    private fun observeScannedCens() {
         disposables += bleManager.scanObservable
             .subscribeBy(onNext = {
-                cenRepo.insertCEN(it)
+                coepiRepo.storeObservedCen(it)
             }, onError = {
                 log.e("Error scanning: $it")
             })

--- a/app/src/main/java/org/coepi/android/cen/CenRepoNew.kt
+++ b/app/src/main/java/org/coepi/android/cen/CenRepoNew.kt
@@ -1,0 +1,2 @@
+package org.coepi.android.cen
+

--- a/app/src/main/java/org/coepi/android/repo/CoEpiRepo.kt
+++ b/app/src/main/java/org/coepi/android/repo/CoEpiRepo.kt
@@ -1,0 +1,32 @@
+package org.coepi.android.repo
+
+import io.reactivex.Completable
+import io.reactivex.Observable
+import org.coepi.android.cen.Cen
+import org.coepi.android.cen.CenRepo
+import org.coepi.android.cen.CenReport
+
+interface CoEpiRepo {
+    // Infection reports fetched periodically from the API
+    val reports: Observable<List<CenReport>>
+
+    // Store CEN from other device
+    fun storeObservedCen(cen: Cen)
+
+    // Send symptoms report
+    fun sendReport(report: CenReport): Completable
+}
+
+class CoepiRepoImpl(
+    private val cenRepo: CenRepo
+) : CoEpiRepo {
+
+    override val reports: Observable<List<CenReport>> = cenRepo.reports
+
+    override fun sendReport(report: CenReport): Completable =
+        cenRepo.sendReport(report)
+
+    override fun storeObservedCen(cen: Cen) {
+        cenRepo.storeCen(cen)
+    }
+}

--- a/app/src/main/java/org/coepi/android/repo/RepoModule.kt
+++ b/app/src/main/java/org/coepi/android/repo/RepoModule.kt
@@ -1,5 +1,7 @@
 package org.coepi.android.repo
 
+import org.coepi.android.cen.CenRepo
+import org.coepi.android.cen.CenRepoImpl
 import org.coepi.android.repo.realm.ContactRepo
 import org.coepi.android.repo.realm.RealmContactRepo
 import org.koin.android.ext.koin.androidApplication

--- a/app/src/main/java/org/coepi/android/ui/cen/CENViewModel.kt
+++ b/app/src/main/java/org/coepi/android/ui/cen/CENViewModel.kt
@@ -17,7 +17,7 @@ class CENViewModel(
 ) : ViewModel() {
 
     // CEN being broadcast by this device
-    val myCurrentCEN = repo.cen
+    val myCurrentCEN = repo.generatedCen
         .map { it.toString() }
         .toLiveData()
 
@@ -39,4 +39,3 @@ class CENViewModel(
         // symptoms.value = symptomsDao.findByRange(0, 99999999999)
     }
 }
-


### PR DESCRIPTION
This repo encapsulates the core business logic/db/api and allows to swap our current implementation with the Rust module.

The interface has these 3 methods:

```kotlin
// Infection reports fetched periodically from the API
val reports: Observable<List<CenReport>>

// Store CEN from other device
fun storeObservedCen(cen: Cen)

// Send symptoms report
fun sendReport(report: CenReport): Completable
```

This should match the interface discussed with @GallagherCommaJack .

The bridging to rx (Observable/Completable) will be done with internal "glue".