### PR TITLE
store last call to KeysCheck

### DIFF
--- a/app/src/main/java/org/coepi/android/cen/CENModule.kt
+++ b/app/src/main/java/org/coepi/android/cen/CENModule.kt
@@ -8,7 +8,8 @@ val CENModule = module {
     single { RealmCenDao(get()) }
     single { RealmCenReportDao(get()) }
     single { RealmCenKeyDao(get()) }
-    single<CenRepo> { CenRepoImpl(get(), get(), get(), get()) }
+    single { RealmCenLastKeysCheckDao(get()) }
+    single<CenRepo> { CenRepoImpl(get(), get(), get(), get(), get()) }
     single<CoEpiRepo> { CoepiRepoImpl(get()) }
     single { CenManager(get(), get(), get(), get()) }
 }

--- a/app/src/main/java/org/coepi/android/cen/RealmCenLastKeysCheck.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmCenLastKeysCheck.kt
@@ -1,0 +1,8 @@
+package org.coepi.android.cen
+
+import io.realm.RealmObject
+import java.util.Date
+
+open class RealmCenLastKeysCheck(
+    var timestamp: Int = 0
+): RealmObject()

--- a/app/src/main/java/org/coepi/android/cen/RealmCenLastKeysCheckDao.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmCenLastKeysCheckDao.kt
@@ -1,0 +1,29 @@
+package org.coepi.android.cen
+
+import io.realm.Sort.DESCENDING
+import io.realm.kotlin.createObject
+import io.realm.kotlin.where
+import org.coepi.android.repo.RealmProvider
+
+class RealmCenLastKeysCheckDao(private val realmProvider: RealmProvider) {
+    private val realm get() = realmProvider.realm
+
+    fun lastCENKeysCheck(limit : Int): List<RealmCenLastKeysCheck> =
+        realm.where<RealmCenLastKeysCheck>()
+            .sort("timestamp", DESCENDING)
+            .limit(limit.toLong())
+            .findAll()
+
+    fun insert(timestamp: Int) {
+        realm.executeTransaction {
+            val realmObj = realm.createObject<RealmCenLastKeysCheck>()
+            realmObj.timestamp = timestamp
+        }
+    }
+
+//    @Query("SELECT * FROM cenkey WHERE :first <= timeStamp AND timeStamp <= :last LIMIT 1")
+//    fun findByRange(first: Int?, last: Int?): List<CENKey>?
+
+//    @Delete
+//    fun deleteBefore(timestamp : Int)
+}


### PR DESCRIPTION
store the timestamp of lats keycheck, so that we can avoid downloading all the keys all time
for same key more reports may be sent, avoid process the same key more than once.