### PR TITLE
Added "extractNativeLibs" to application section of AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,8 @@
         android:supportsRtl="true"
         android:extractNativeLibs="true"
         android:theme="@style/AppTheme">
+        <!-- TODO: Investigate installation error and remove extractNativeLibs from manifest
+         see https://github.com/Co-Epi/app-android/pull/59#issuecomment-611193577 -->
         <activity android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.Launcher">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:extractNativeLibs="true"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity"
             android:label="@string/app_name"


### PR DESCRIPTION
Fixes the following error that occurs when trying to install the apk on Android 10.

"Failure [INSTALL_FAILED_INVALID_APK: Failed to extract native libraries, res=-2]"

@i-schuetz not sure if this is the right way to fix this or if there's a better alternative. Open to suggestions.