### PR TITLE
Fix alerts not updating

### DIFF
--- a/app/src/main/java/org/coepi/android/cen/CENModule.kt
+++ b/app/src/main/java/org/coepi/android/cen/CENModule.kt
@@ -10,7 +10,7 @@ import org.coepi.android.repo.CoepiRepoImpl
 import org.koin.dsl.module
 
 val CENModule = module {
-    single { RealmCenDao(get()) }
+    single(createdAtStart = true) { RealmCenDao(get()) }
     single { RealmCenReportDao(get()) }
     single { RealmCenKeyDao(get()) }
     single<CenReportRepo> { CenReportRepoImpl(get(), get()) }


### PR DESCRIPTION
The worker was crashing due to Realm instantiation in worker. Eager
instantiation prevents it from being instantiated in worker.

https://github.com/realm/realm-java/issues/5009