### PR TITLE
Make dates/timestamps type safe

### DIFF
--- a/app/src/main/java/org/coepi/android/api/CENApi.kt
+++ b/app/src/main/java/org/coepi/android/api/CENApi.kt
@@ -16,7 +16,7 @@ interface CENApi {
 
     // get recent keys that have CEN Reports
     @GET("cenkeys/{timestamp}")
-    fun cenkeysCheck(@Path("timestamp") timestamp : Int): Call<List<String>>
+    fun cenkeysCheck(@Path("timestamp") timestamp : Long): Call<List<String>>
 
     // get report based on matched CENkey
     @GET("cenreport/{key}")

--- a/app/src/main/java/org/coepi/android/api/request/ApiParamsCenReport.kt
+++ b/app/src/main/java/org/coepi/android/api/request/ApiParamsCenReport.kt
@@ -9,7 +9,7 @@ data class ApiParamsCenReport(
     var reportID: String,
     var report: String,
     var cenKeys: String,
-    var reportTimeStamp: Long // Unix time, seconds
+    var reportTimeStamp: Long // Unix time
 )
 
 fun SymptomReport.toApiParamsCenReport(keys: List<CenKey>) =

--- a/app/src/main/java/org/coepi/android/api/request/ApiParamsCenReport.kt
+++ b/app/src/main/java/org/coepi/android/api/request/ApiParamsCenReport.kt
@@ -2,22 +2,20 @@ package org.coepi.android.api.request
 
 import org.coepi.android.cen.CenKey
 import org.coepi.android.cen.SymptomReport
-import org.coepi.android.extensions.coEpiTimestamp
 import org.coepi.android.extensions.toBase64
 import org.coepi.android.extensions.toHex
-import java.util.Date
 
 data class ApiParamsCenReport(
     var reportID: String,
     var report: String,
     var cenKeys: String,
-    var reportTimeStamp: Long
+    var reportTimeStamp: Long // Unix time, seconds
 )
 
 fun SymptomReport.toApiParamsCenReport(keys: List<CenKey>) =
     ApiParamsCenReport(
         reportID = id.toByteArray().toHex(),
         report = report.toBase64(),
-        cenKeys = keys.joinToString(",") { it.key }, //this has to be HEX
-        reportTimeStamp = Date().coEpiTimestamp()
+        cenKeys = keys.joinToString(",") { it.key }, // hex
+        reportTimeStamp = date.unixTime
     )

--- a/app/src/main/java/org/coepi/android/cen/CenKey.kt
+++ b/app/src/main/java/org/coepi/android/cen/CenKey.kt
@@ -1,6 +1,8 @@
 package org.coepi.android.cen
 
+import org.coepi.android.domain.CoEpiDate
+
 data class CenKey(
     val key: String, // Hex
-    val timestamp: Long
+    val date: CoEpiDate
 )

--- a/app/src/main/java/org/coepi/android/cen/MyCenProvider.kt
+++ b/app/src/main/java/org/coepi/android/cen/MyCenProvider.kt
@@ -4,11 +4,12 @@ import io.reactivex.Observable
 import io.reactivex.Observable.empty
 import io.reactivex.Observable.just
 import org.coepi.android.domain.CenLogic
-import org.coepi.android.extensions.coEpiTimestamp
+import org.coepi.android.domain.CoEpiDate
+import org.coepi.android.domain.CoEpiDate.Companion.minDate
+import org.coepi.android.domain.CoEpiDate.Companion.now
 import org.coepi.android.system.log.LogTag.CEN_L
 import org.coepi.android.system.log.log
 import org.coepi.android.ui.debug.DebugBleObservable
-import java.util.Date
 import java.util.concurrent.TimeUnit.MINUTES
 
 interface MyCenProvider {
@@ -21,17 +22,17 @@ class MyCenProviderImpl(
     private val debugObservable: DebugBleObservable
 ) : MyCenProvider {
 
-    private var cenKeyTimestamp = 0L // TODO maybe observe directly a database query with the last key
+    private var cenKeyTimestamp: CoEpiDate = minDate() // TODO maybe observe directly a database query with the last key
 
     override val cen: Observable<Cen> = Observable.interval(0, 15, MINUTES)
         .flatMap { generateAndStoreNewCenKeyIfNeeded() }
         .doOnNext { debugObservable.setMyKey(it) }
-        .map { key -> cenLogic.generateCen(key, key.timestamp) }
+        .map { key -> cenLogic.generateCen(key, key.date.unixTime) }
         .doOnNext { debugObservable.setMyCen(it) }
         .share()
 
     private fun generateAndStoreNewCenKeyIfNeeded(): Observable<CenKey> {
-        val curTimestamp = Date().coEpiTimestamp()
+        val curTimestamp: CoEpiDate = now()
         return if (cenLogic.shouldGenerateNewCenKey(curTimestamp, cenKeyTimestamp)) {
             val key = cenLogic.generateCenKey(curTimestamp)
             log.i("Generated a new CEN key: $key", CEN_L)

--- a/app/src/main/java/org/coepi/android/cen/RealmCenDao.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmCenDao.kt
@@ -3,6 +3,7 @@ package org.coepi.android.cen
 import io.realm.kotlin.createObject
 import io.realm.kotlin.oneOf
 import io.realm.kotlin.where
+import org.coepi.android.domain.CoEpiDate
 import org.coepi.android.repo.RealmProvider
 
 class RealmCenDao(private val realmProvider: RealmProvider) {
@@ -11,11 +12,11 @@ class RealmCenDao(private val realmProvider: RealmProvider) {
     fun all(): List<RealmReceivedCen> =
         realm.where<RealmReceivedCen>().findAll()
 
-    fun matchCENs(start: Long, end: Long, cens: Array<String>): List<RealmReceivedCen> =
+    fun matchCENs(start: CoEpiDate, end: CoEpiDate, cens: Array<String>): List<RealmReceivedCen> =
         realm.where<RealmReceivedCen>()
-            .greaterThanOrEqualTo("timestamp", start)
+            .greaterThanOrEqualTo("timestamp", start.unixTime)
             .and()
-            .lessThanOrEqualTo("timestamp", end)
+            .lessThanOrEqualTo("timestamp", end.unixTime)
             .and()
             .oneOf("cen", cens)
             .findAll()
@@ -32,7 +33,7 @@ class RealmCenDao(private val realmProvider: RealmProvider) {
         }
         realm.executeTransaction {
             val realmObj = realm.createObject<RealmReceivedCen>(cen.cen.toHex()) // Create a new object
-            realmObj.timestamp = cen.timestamp
+            realmObj.timestamp = cen.date.unixTime
         }
         return true
     }

--- a/app/src/main/java/org/coepi/android/cen/RealmCenKey.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmCenKey.kt
@@ -2,14 +2,11 @@ package org.coepi.android.cen
 
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
-import org.coepi.android.domain.CoEpiDate
-import org.coepi.android.domain.CoEpiDate.Companion
-import org.coepi.android.domain.CoEpiDate.Companion.fromSeconds
-import java.util.Date
+import org.coepi.android.domain.CoEpiDate.Companion.fromUnixTime
 
 open class RealmCenKey(
     @PrimaryKey var key: String = "",
-    var timestamp: Long = 0 // Unix time, seconds
+    var timestamp: Long = 0 // Unix time
 ): RealmObject()
 
-fun RealmCenKey.toCenKey() = CenKey(key, fromSeconds(timestamp))
+fun RealmCenKey.toCenKey() = CenKey(key, fromUnixTime(timestamp))

--- a/app/src/main/java/org/coepi/android/cen/RealmCenKey.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmCenKey.kt
@@ -2,11 +2,14 @@ package org.coepi.android.cen
 
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
+import org.coepi.android.domain.CoEpiDate
+import org.coepi.android.domain.CoEpiDate.Companion
+import org.coepi.android.domain.CoEpiDate.Companion.fromSeconds
 import java.util.Date
 
 open class RealmCenKey(
     @PrimaryKey var key: String = "",
-    var timestamp: Long = 0
+    var timestamp: Long = 0 // Unix time, seconds
 ): RealmObject()
 
-fun RealmCenKey.toCenKey() = CenKey(key, timestamp)
+fun RealmCenKey.toCenKey() = CenKey(key, fromSeconds(timestamp))

--- a/app/src/main/java/org/coepi/android/cen/RealmCenKeyDao.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmCenKeyDao.kt
@@ -17,7 +17,7 @@ class RealmCenKeyDao(private val realmProvider: RealmProvider) {
     fun insert(key: CenKey) {
         realm.executeTransaction {
             val realmObj = realm.createObject<RealmCenKey>(key.key)
-            realmObj.timestamp = key.timestamp
+            realmObj.timestamp = key.date.unixTime
         }
     }
 }

--- a/app/src/main/java/org/coepi/android/cen/RealmReceivedCen.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmReceivedCen.kt
@@ -5,5 +5,5 @@ import io.realm.annotations.PrimaryKey
 
 open class RealmReceivedCen(
     @PrimaryKey var cen: String = "", // Hex encoding
-    var timestamp: Long = 0
+    var timestamp: Long = 0 // Unix time, seconds
 ): RealmObject()

--- a/app/src/main/java/org/coepi/android/cen/RealmReceivedCen.kt
+++ b/app/src/main/java/org/coepi/android/cen/RealmReceivedCen.kt
@@ -5,5 +5,5 @@ import io.realm.annotations.PrimaryKey
 
 open class RealmReceivedCen(
     @PrimaryKey var cen: String = "", // Hex encoding
-    var timestamp: Long = 0 // Unix time, seconds
+    var timestamp: Long = 0 // Unix time
 ): RealmObject()

--- a/app/src/main/java/org/coepi/android/cen/ReceivedCen.kt
+++ b/app/src/main/java/org/coepi/android/cen/ReceivedCen.kt
@@ -1,3 +1,5 @@
 package org.coepi.android.cen
 
-data class ReceivedCen(val cen: Cen, val timestamp: Long)
+import org.coepi.android.domain.CoEpiDate
+
+data class ReceivedCen(val cen: Cen, val date: CoEpiDate)

--- a/app/src/main/java/org/coepi/android/cen/SymptomReport.kt
+++ b/app/src/main/java/org/coepi/android/cen/SymptomReport.kt
@@ -1,7 +1,9 @@
 package org.coepi.android.cen
 
+import org.coepi.android.domain.CoEpiDate
+
 data class SymptomReport(
     var id: String,
     var report: String,
-    var timestamp: Long
+    var date: CoEpiDate
 )

--- a/app/src/main/java/org/coepi/android/cross/ScannedCensHandler.kt
+++ b/app/src/main/java/org/coepi/android/cross/ScannedCensHandler.kt
@@ -5,10 +5,9 @@ import io.reactivex.rxkotlin.plusAssign
 import io.reactivex.rxkotlin.subscribeBy
 import org.coepi.android.ble.BleManager
 import org.coepi.android.cen.ReceivedCen
-import org.coepi.android.extensions.coEpiTimestamp
+import org.coepi.android.domain.CoEpiDate.Companion.now
 import org.coepi.android.repo.CoEpiRepo
 import org.coepi.android.system.log.log
-import java.util.Date
 
 class ScannedCensHandler(
     bleManager: BleManager,
@@ -19,7 +18,7 @@ class ScannedCensHandler(
     init {
         disposables += bleManager.observedCens
             .subscribeBy(onNext = { cen ->
-                coEpiRepo.storeObservedCen(ReceivedCen(cen, Date().coEpiTimestamp()))
+                coEpiRepo.storeObservedCen(ReceivedCen(cen, now()))
             }, onError = {
                 log.e("Error scanning: $it")
             })

--- a/app/src/main/java/org/coepi/android/domain/CenLogic.kt
+++ b/app/src/main/java/org/coepi/android/domain/CenLogic.kt
@@ -15,7 +15,7 @@ interface CenLogic {
     fun generateCenKey(date: CoEpiDate): CenKey
 
     /**
-     * @param ts Unix time, seconds
+     * @param ts Unix time
      */
     fun generateCen(cenKey: CenKey, ts: Long): Cen
 }

--- a/app/src/main/java/org/coepi/android/domain/CenLogic.kt
+++ b/app/src/main/java/org/coepi/android/domain/CenLogic.kt
@@ -1,6 +1,5 @@
 package org.coepi.android.domain
 
-import android.util.Base64
 import org.coepi.android.cen.Cen
 import org.coepi.android.cen.CenKey
 import org.coepi.android.cen.IntToByteArray
@@ -12,23 +11,28 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 
 interface CenLogic {
-    fun shouldGenerateNewCenKey(curTimestamp: Long, cenKeyTimestamp: Long): Boolean
-    fun generateCenKey(timeStamp: Long): CenKey
+    fun shouldGenerateNewCenKey(curDate: CoEpiDate, cenKeyDate: CoEpiDate): Boolean
+    fun generateCenKey(date: CoEpiDate): CenKey
+
+    /**
+     * @param ts Unix time, seconds
+     */
     fun generateCen(cenKey: CenKey, ts: Long): Cen
 }
 
 class CenLogicImpl: CenLogic {
     private val cenKeyLifetimeInSeconds = 7 * 86400 // every 7 days a new key is generated
 
-    override fun shouldGenerateNewCenKey(curTimestamp: Long, cenKeyTimestamp: Long): Boolean =
-        (cenKeyTimestamp == 0L) || (roundedTimestamp(curTimestamp) > roundedTimestamp(cenKeyTimestamp))
+    override fun shouldGenerateNewCenKey(curDate: CoEpiDate, cenDate: CoEpiDate): Boolean =
+        (cenDate.unixTime == 0L) || (roundedTimestamp(curDate.unixTime) >
+                roundedTimestamp(cenDate.unixTime))
 
-    override fun generateCenKey(timeStamp: Long): CenKey {
+    override fun generateCenKey(date: CoEpiDate): CenKey {
         // generate a new AES Key and store it in local storage
         val secretKey = KeyGenerator.getInstance("AES")
             .apply { init(256) } // 32 bytes
             .generateKey()
-        return CenKey(secretKey.encoded.toHex(), timeStamp)
+        return CenKey(secretKey.encoded.toHex(), date)
     }
 
     override fun generateCen(cenKey: CenKey, ts: Long): Cen {

--- a/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
+++ b/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
@@ -3,12 +3,11 @@ package org.coepi.android.domain
 import org.coepi.android.cen.CenKey
 import org.coepi.android.cen.RealmCenDao
 import org.coepi.android.cen.RealmReceivedCen
-import org.coepi.android.extensions.coEpiTimestamp
-import java.util.Date
+import org.coepi.android.domain.CoEpiDate.Companion.fromSeconds
 
 interface CenMatcher {
-    fun hasMatches(key: CenKey, maxTimestamp: Long): Boolean
-    fun match(key: CenKey, maxTimestamp: Long): List<RealmReceivedCen>
+    fun hasMatches(key: CenKey, maxDate: CoEpiDate): Boolean
+    fun match(key: CenKey, maxDate: CoEpiDate): List<RealmReceivedCen>
 }
 
 class CenMatcherImpl(
@@ -17,26 +16,26 @@ class CenMatcherImpl(
 ) : CenMatcher {
     private val cenLifetimeInSeconds = 15 * 60   // every 15 mins a new CEN is generated
 
-    override fun hasMatches(key: CenKey, maxTimestamp: Long): Boolean =
-        match(key, maxTimestamp).isNotEmpty()
+    override fun hasMatches(key: CenKey, maxDate: CoEpiDate): Boolean =
+        match(key, maxDate).isNotEmpty()
 
     // matchCENKey uses a publicized key and finds matches with one database call per key
     //  Not efficient... It would be best if all observed CENs are loaded into memory
-    override fun match(key: CenKey, maxTimestamp: Long): List<RealmReceivedCen> {
+    override fun match(key: CenKey, maxDate: CoEpiDate): List<RealmReceivedCen> {
         val secondsInAWeek: Long = 604800
 
         // take the last 7 days of timestamps and generate all the possible CENs (e.g. 7 days) TODO: Parallelize this?
 
-        val minTimestamp = maxTimestamp - secondsInAWeek
+        val minTimestampSeconds = maxDate.unixTime - secondsInAWeek
         val possibleCensCount = (secondsInAWeek / cenLifetimeInSeconds).toInt()
 
         val possibleCENs = Array(possibleCensCount) { i ->
-            val ts = maxTimestamp - cenLifetimeInSeconds * i
+            val ts = maxDate.unixTime - cenLifetimeInSeconds * i
             val cen = cenLogic.generateCen(key, ts)
             cen.toHex()
         }
 
         // check if the possibleCENs are in the CEN Table
-        return cenDao.matchCENs(minTimestamp, maxTimestamp, possibleCENs)
+        return cenDao.matchCENs(fromSeconds(minTimestampSeconds), maxDate, possibleCENs)
     }
 }

--- a/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
+++ b/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
@@ -3,7 +3,7 @@ package org.coepi.android.domain
 import org.coepi.android.cen.CenKey
 import org.coepi.android.cen.RealmCenDao
 import org.coepi.android.cen.RealmReceivedCen
-import org.coepi.android.domain.CoEpiDate.Companion.fromSeconds
+import org.coepi.android.domain.CoEpiDate.Companion.fromUnixTime
 
 interface CenMatcher {
     fun hasMatches(key: CenKey, maxDate: CoEpiDate): Boolean
@@ -36,6 +36,6 @@ class CenMatcherImpl(
         }
 
         // check if the possibleCENs are in the CEN Table
-        return cenDao.matchCENs(fromSeconds(minTimestampSeconds), maxDate, possibleCENs)
+        return cenDao.matchCENs(fromUnixTime(minTimestampSeconds), maxDate, possibleCENs)
     }
 }

--- a/app/src/main/java/org/coepi/android/domain/CoEpiDate.kt
+++ b/app/src/main/java/org/coepi/android/domain/CoEpiDate.kt
@@ -1,0 +1,28 @@
+package org.coepi.android.domain
+
+import java.util.Date
+
+data class CoEpiDate(private val date: Date) {
+    val unixTime: Long = date.time / 1000
+
+    companion object {
+
+        /**
+         * @param timestamp Unix time (millis)
+         */
+        private fun fromMillis(timestamp: Long): CoEpiDate =
+            CoEpiDate(Date(timestamp))
+
+        /**
+         * @param timestamp Unix time
+         */
+        fun fromSeconds(timestamp: Long): CoEpiDate =
+            fromMillis(timestamp * 1000)
+
+        fun minDate(): CoEpiDate =
+            CoEpiDate(Date(0))
+
+        fun now(): CoEpiDate =
+            CoEpiDate(Date())
+    }
+}

--- a/app/src/main/java/org/coepi/android/domain/CoEpiDate.kt
+++ b/app/src/main/java/org/coepi/android/domain/CoEpiDate.kt
@@ -2,27 +2,17 @@ package org.coepi.android.domain
 
 import java.util.Date
 
-data class CoEpiDate(private val date: Date) {
-    val unixTime: Long = date.time / 1000
+data class CoEpiDate(val unixTime: Long) {
 
     companion object {
 
-        /**
-         * @param timestamp Unix time (millis)
-         */
-        private fun fromMillis(timestamp: Long): CoEpiDate =
-            CoEpiDate(Date(timestamp))
-
-        /**
-         * @param timestamp Unix time
-         */
-        fun fromSeconds(timestamp: Long): CoEpiDate =
-            fromMillis(timestamp * 1000)
+        fun fromUnixTime(unixTime: Long): CoEpiDate =
+            CoEpiDate(unixTime)
 
         fun minDate(): CoEpiDate =
-            CoEpiDate(Date(0))
+            CoEpiDate(0)
 
         fun now(): CoEpiDate =
-            CoEpiDate(Date())
+            CoEpiDate(Date().time / 1000)
     }
 }

--- a/app/src/main/java/org/coepi/android/extensions/DateExtensions.kt
+++ b/app/src/main/java/org/coepi/android/extensions/DateExtensions.kt
@@ -1,6 +1,0 @@
-package org.coepi.android.extensions
-
-import java.util.Date
-
-// Unix time (seconds)
-fun Date.coEpiTimestamp() = time / 1000

--- a/app/src/main/java/org/coepi/android/repo/SymptomRepo.kt
+++ b/app/src/main/java/org/coepi/android/repo/SymptomRepo.kt
@@ -2,11 +2,11 @@ package org.coepi.android.repo
 
 import io.reactivex.Observable
 import io.reactivex.Single
-import org.coepi.android.cen.CenReportRepo
 import org.coepi.android.cen.SymptomReport
+import org.coepi.android.domain.CoEpiDate
+import org.coepi.android.domain.CoEpiDate.Companion.now
 import org.coepi.android.system.rx.VoidOperationState
 import org.coepi.android.domain.model.Symptom
-import org.coepi.android.extensions.coEpiTimestamp
 import java.util.Date
 import java.util.UUID.randomUUID
 
@@ -41,7 +41,7 @@ class SymptomRepoImpl(
         coEpiRepo.sendReport(SymptomReport(
             id = randomUUID().toString(),
             report = "TODO symptoms -> report",
-            timestamp = Date().coEpiTimestamp()
+            date = now()
         ))
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/debug/cen/CENViewModel.kt
+++ b/app/src/main/java/org/coepi/android/ui/debug/cen/CENViewModel.kt
@@ -1,18 +1,17 @@
 package org.coepi.android.ui.debug.cen
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import org.coepi.android.ble.BleManager
 import org.coepi.android.cen.Cen
 import org.coepi.android.cen.MyCenProvider
 import org.coepi.android.cen.RealmCenReport
 import org.coepi.android.cen.ReceivedCen
-import org.coepi.android.extensions.coEpiTimestamp
+import org.coepi.android.domain.CoEpiDate.Companion.now
+import org.coepi.android.extensions.hexToByteArray
 import org.coepi.android.extensions.rx.toLiveData
 import org.coepi.android.repo.CoEpiRepo
-import org.coepi.android.extensions.hexToByteArray
-import java.util.Date
 
 class CENViewModel(
     myCenProvider: MyCenProvider,
@@ -46,7 +45,7 @@ class CENViewModel(
     fun insertPastedCEN(centoinsert: String = "") {
         val curcenbytes = centoinsert.hexToByteArray()
         val c = Cen(curcenbytes)
-        coeEpiRepo.storeObservedCen(ReceivedCen(c, Date().coEpiTimestamp()))
+        coeEpiRepo.storeObservedCen(ReceivedCen(c, now()))
     }
 
     private fun update() {


### PR DESCRIPTION
Now most of the code handles `CoEpiDate`, which ensures we use unix timestamp in seconds. We still use the raw timestamp in the database/API objects and when matching, for performance.