### PR TITLE
Fetch keys only since last fetch

### DIFF
--- a/app/src/main/java/org/coepi/android/domain/CoEpiDate.kt
+++ b/app/src/main/java/org/coepi/android/domain/CoEpiDate.kt
@@ -5,7 +5,6 @@ import java.util.Date
 data class CoEpiDate(val unixTime: Long) {
 
     companion object {
-
         fun fromUnixTime(unixTime: Long): CoEpiDate =
             CoEpiDate(unixTime)
 
@@ -16,3 +15,6 @@ data class CoEpiDate(val unixTime: Long) {
             CoEpiDate(Date().time / 1000)
     }
 }
+
+fun CoEpiDate.debugString() =
+    "$unixTime, ${Date(unixTime * 1000)} "

--- a/app/src/main/java/org/coepi/android/system/Preferences.kt
+++ b/app/src/main/java/org/coepi/android/system/Preferences.kt
@@ -3,7 +3,8 @@ package org.coepi.android.system
 import android.content.SharedPreferences
 
 enum class PreferencesKey {
-    SEEN_ONBOARDING
+    SEEN_ONBOARDING,
+    LAST_CEN_KEYS_FETCH_TIMESTAMP // Unix time
 }
 
 class Preferences(private val sharedPreferences: SharedPreferences) {
@@ -14,6 +15,19 @@ class Preferences(private val sharedPreferences: SharedPreferences) {
     fun putBoolean(key: PreferencesKey, value: Boolean?) {
         putOrClear(key, value) {
             sharedPreferences.edit().putBoolean(key.toString(), it).apply()
+        }
+    }
+
+    fun getLong(key: PreferencesKey): Long? =
+        if (sharedPreferences.contains(key.toString())) {
+            sharedPreferences.getLong(key.toString(), -1)
+        } else {
+            null
+        }
+
+    fun putLong(key: PreferencesKey, value: Long?) {
+        putOrClear(key, value) {
+            sharedPreferences.edit().putLong(key.toString(), it).apply()
         }
     }
 

--- a/app/src/main/java/org/coepi/android/worker/cenfetcher/ContactsFetchWorker.kt
+++ b/app/src/main/java/org/coepi/android/worker/cenfetcher/ContactsFetchWorker.kt
@@ -8,8 +8,15 @@ import androidx.work.workDataOf
 import kotlinx.coroutines.delay
 import org.coepi.android.cen.RealmCenReportDao
 import org.coepi.android.cen.ReceivedCenReport
+import org.coepi.android.common.doIfSuccess
 import org.coepi.android.common.successOrNull
+import org.coepi.android.domain.CoEpiDate
+import org.coepi.android.domain.CoEpiDate.Companion.fromUnixTime
+import org.coepi.android.domain.CoEpiDate.Companion.minDate
+import org.coepi.android.domain.CoEpiDate.Companion.now
 import org.coepi.android.repo.CoEpiRepo
+import org.coepi.android.system.Preferences
+import org.coepi.android.system.PreferencesKey.LAST_CEN_KEYS_FETCH_TIMESTAMP
 import org.coepi.android.system.log.LogTag.CEN_MATCHING
 import org.coepi.android.system.log.log
 import org.koin.core.KoinComponent
@@ -22,15 +29,28 @@ class ContactsFetchWorker(
 
     private val coEpiRepo: CoEpiRepo by inject()
     private val reportsDao: RealmCenReportDao by inject()
+    private val preferences: Preferences by inject()
 
     override suspend fun doWork(): Result {
         log.d("Contacts fetch worker started...", CEN_MATCHING)
 
-        val reportsResult = coEpiRepo.reports()
+        val fromDate: CoEpiDate = preferences.getLong(LAST_CEN_KEYS_FETCH_TIMESTAMP)?.let {
+            fromUnixTime(it)
+        } ?: minDate()
+
+        val nowBeforeRequest: CoEpiDate = now()
+
+        val reportsResult =
+            coEpiRepo.reports(fromDate)
         val reports: List<ReceivedCenReport> = reportsResult.successOrNull() ?: emptyList()
 
         reports.forEach {
             reportsDao.insert(it.report)
+        }
+
+        // After reports saved successfully, store the fetch timestamp
+        reportsResult.doIfSuccess {
+            preferences.putLong(LAST_CEN_KEYS_FETCH_TIMESTAMP, nowBeforeRequest.unixTime)
         }
 
         setProgress(workDataOf(CONTACT_COUNT_KEY to reports.size))
@@ -39,6 +59,7 @@ class ContactsFetchWorker(
         delay(100)
 
         log.i("Contacts fetch worker finished. Saved reports: ${reports.size}", CEN_MATCHING)
+
         return success()
     }
 


### PR DESCRIPTION
Note: The backend doesn't seem to support the timestamp yet. It ignores it.