### PR TITLE
CEN matching optimizations

### DIFF
--- a/app/src/main/java/org/coepi/android/cen/CENModule.kt
+++ b/app/src/main/java/org/coepi/android/cen/CENModule.kt
@@ -14,7 +14,7 @@ val CENModule = module {
     single { RealmCenReportDao(get()) }
     single { RealmCenKeyDao(get()) }
     single<CenReportRepo> { CenReportRepoImpl(get(), get(), get()) }
-    single<CenMatcher> { CenMatcherImpl(get(), get()) }
+    single<CenMatcher> { CenMatcherImpl(get()) }
     single<CenLogic> { CenLogicImpl() }
     single<CoEpiRepo> { CoepiRepoImpl(get(), get(), get(), get(), get()) }
     single<MyCenProvider> { MyCenProviderImpl(get(), get(), get()) }

--- a/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
+++ b/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
@@ -2,6 +2,7 @@ package org.coepi.android.domain
 
 import kotlinx.coroutines.Dispatchers.Default
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.coepi.android.cen.Cen
@@ -34,7 +35,7 @@ class CenMatcherImpl(
                         null
                     }
                 }
-            }.mapNotNull { it.await() }
+            }.awaitAll().filterNotNull()
         }
 
     private fun match(censSet: Set<String>, key: CenKey, maxDate: CoEpiDate): Boolean {

--- a/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
+++ b/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
@@ -2,40 +2,29 @@ package org.coepi.android.domain
 
 import org.coepi.android.cen.CenKey
 import org.coepi.android.cen.RealmCenDao
-import org.coepi.android.cen.RealmReceivedCen
-import org.coepi.android.domain.CoEpiDate.Companion.fromUnixTime
 
 interface CenMatcher {
-    fun hasMatches(key: CenKey, maxDate: CoEpiDate): Boolean
-    fun match(key: CenKey, maxDate: CoEpiDate): List<RealmReceivedCen>
+    fun hasMatches(cens: List<ByteArray>, key: CenKey, maxDate: CoEpiDate): Boolean
 }
 
 class CenMatcherImpl(
-    private val cenDao: RealmCenDao,
     private val cenLogic: CenLogic
 ) : CenMatcher {
     private val cenLifetimeInSeconds = 15 * 60   // every 15 mins a new CEN is generated
 
-    override fun hasMatches(key: CenKey, maxDate: CoEpiDate): Boolean =
-        match(key, maxDate).isNotEmpty()
+    override fun hasMatches(cens: List<ByteArray>, key: CenKey, maxDate: CoEpiDate): Boolean {
+        val censSet: Set<ByteArray> = cens.toSet()
 
-    // matchCENKey uses a publicized key and finds matches with one database call per key
-    //  Not efficient... It would be best if all observed CENs are loaded into memory
-    override fun match(key: CenKey, maxDate: CoEpiDate): List<RealmReceivedCen> {
         val secondsInAWeek: Long = 604800
 
-        // take the last 7 days of timestamps and generate all the possible CENs (e.g. 7 days) TODO: Parallelize this?
-
-        val minTimestampSeconds = maxDate.unixTime - secondsInAWeek
         val possibleCensCount = (secondsInAWeek / cenLifetimeInSeconds).toInt()
-
-        val possibleCENs = Array(possibleCensCount) { i ->
+        for (i in 0..possibleCensCount) {
             val ts = maxDate.unixTime - cenLifetimeInSeconds * i
             val cen = cenLogic.generateCen(key, ts)
-            cen.toHex()
+            if (censSet.contains(cen.bytes)) {
+                return true
+            }
         }
-
-        // check if the possibleCENs are in the CEN Table
-        return cenDao.matchCENs(fromUnixTime(minTimestampSeconds), maxDate, possibleCENs)
+        return false
     }
 }

--- a/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
+++ b/app/src/main/java/org/coepi/android/domain/CenMatcher.kt
@@ -26,7 +26,7 @@ class CenMatcherImpl(
     private suspend fun matchSuspended(cens: List<Cen>, keys: List<CenKey>,
                                        maxDate: CoEpiDate): List<CenKey> =
         coroutineScope {
-            val censSet: Set<String> = cens.map { it.toHex() }.toSet()
+            val censSet: Set<String> = cens.map { it.toHex() }.toHashSet()
             keys.distinct().map { key ->
                 async(Default) {
                     if (match(censSet, key, maxDate)) {

--- a/app/src/main/java/org/coepi/android/repo/CoEpiRepo.kt
+++ b/app/src/main/java/org/coepi/android/repo/CoEpiRepo.kt
@@ -10,6 +10,7 @@ import io.reactivex.subjects.PublishSubject.create
 import org.coepi.android.api.CENApi
 import org.coepi.android.api.request.ApiParamsCenReport
 import org.coepi.android.api.toCenReport
+import org.coepi.android.cen.Cen
 import org.coepi.android.cen.CenKey
 import org.coepi.android.cen.RealmCenDao
 import org.coepi.android.cen.RealmCenKeyDao
@@ -29,6 +30,7 @@ import org.coepi.android.domain.CenMatcher
 import org.coepi.android.domain.CoEpiDate
 import org.coepi.android.domain.CoEpiDate.Companion.now
 import org.coepi.android.domain.debugString
+import org.coepi.android.extensions.hexToByteArray
 import org.coepi.android.extensions.rx.toObservable
 import org.coepi.android.extensions.toResult
 import org.coepi.android.system.log.LogTag.CEN_MATCHING
@@ -142,14 +144,17 @@ class CoepiRepoImpl(
 
     private fun filterMatchingKeys(keys: List<CenKey>): List<CenKey> {
         val maxDate: CoEpiDate = now()
+        val cens: List<ByteArray> = cenDao.all().map { it.cen.hexToByteArray() }
+        log.i("Stored CENs: ${cens.size}")
+
         return keys.distinct().mapNotNull { key ->
             //.distinct():same key may arrive more than once, due to multiple reporting
-            if (cenMatcher.hasMatches(key, maxDate)) {
+            if (cenMatcher.hasMatches(cens, key, maxDate)) {
                 key
             } else {
                 null
-        }
             }
+        }
     }
 
     private fun postReport(report: SymptomReport): Completable {

--- a/app/src/main/java/org/coepi/android/repo/CoEpiRepo.kt
+++ b/app/src/main/java/org/coepi/android/repo/CoEpiRepo.kt
@@ -144,17 +144,9 @@ class CoepiRepoImpl(
 
     private fun filterMatchingKeys(keys: List<CenKey>): List<CenKey> {
         val maxDate: CoEpiDate = now()
-        val cens: List<ByteArray> = cenDao.all().map { it.cen.hexToByteArray() }
+        val cens: List<Cen> = cenDao.all().map { Cen(it.cen.hexToByteArray()) }
         log.i("Stored CENs: ${cens.size}")
-
-        return keys.distinct().mapNotNull { key ->
-            //.distinct():same key may arrive more than once, due to multiple reporting
-            if (cenMatcher.hasMatches(cens, key, maxDate)) {
-                key
-            } else {
-                null
-            }
-        }
+        return cenMatcher.match(cens, keys.distinct(), maxDate)
     }
 
     private fun postReport(report: SymptomReport): Completable {

--- a/app/src/main/java/org/coepi/android/repo/CoEpiRepo.kt
+++ b/app/src/main/java/org/coepi/android/repo/CoEpiRepo.kt
@@ -144,6 +144,7 @@ class CoepiRepoImpl(
 
     private fun filterMatchingKeys(keys: List<CenKey>): List<CenKey> {
         val maxDate: CoEpiDate = now()
+        // TODO delete periodically entries older than ~3 weeks from the db
         val cens: List<Cen> = cenDao.all().map { Cen(it.cen.hexToByteArray()) }
         log.i("Stored CENs: ${cens.size}")
         return cenMatcher.match(cens, keys.distinct(), maxDate)


### PR DESCRIPTION
Parallelized matching. This improved performance by 50-60% on the devices I tested with (4 cores). Tested with ~900 keys and less than 20 stored CENs.

This optimization takes into account the planned migration to the v4 API, which will not use timestamps and require to loop through large intervals. Thus the stored timestamp based matching used in iOS wasn't added.