### PR TITLE
#110 Allow App Center to modify Version Code

### DIFF
--- a/app/appcenter-pre-build.sh
+++ b/app/appcenter-pre-build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# App Center Pre-Build Template sourced from:
+# https://github.com/microsoft/appcenter/blob/master/sample-build-scripts/xamarin/version-name/appcenter-pre-build.sh
+
+echo "Running appcenter-pre-build.sh script"
+
+if [ -z "$APPCENTER_BUILD_ID" ]
+then
+    echo "You need define APPCENTER_BUILD_ID variable or run in App Center"
+    exit
+fi
+
+if [ -z "$APPCENTER_SOURCE_DIRECTORY" ]
+then
+    echo "You need define APPCENTER_SOURCE_DIRECTORY variable or run in App Center"
+    exit
+fi
+
+BUILD_GRADLE_FILE=$APPCENTER_SOURCE_DIRECTORY/app/build.gradle
+
+if [ -e "$BUILD_GRADLE_FILE" ]
+then
+    echo "Updating version code to $APPCENTER_BUILD_ID in $BUILD_GRADLE_FILE"
+    sed -i '' 's/versionCode [0-9]*/versionCode '$APPCENTER_BUILD_ID'/' $BUILD_GRADLE_FILE
+    
+    echo "File versionCode content:"
+    cat $BUILD_GRADLE_FILE | grep versionCode
+else
+    echo "File not found: $BUILD_GRADLE_FILE"
+fi
+
+echo "Done running appcenter-pre-build.sh script"
+


### PR DESCRIPTION
Added App Center pre-build script to update version code to the build number for issue #110.

**Note,** App Center will detect this pre-build script automatically with a pretty green checkbox, but it will **NOT** actually update the build process until you manually click "Save & Build" at least once. 

To verify the build is running the script, the log should show something like this where "7" is your build number...

```
##[section]Finishing: Install Android keystore
##[section]Starting: Pre Build Script

[command]/bin/bash /Users/runner/runners/2.166.4/work/1/s/app/appcenter-pre-build.sh
Running appcenter-pre-build.sh script
Updating version code to 7 in /Users/runner/runners/2.166.4/work/1/s/app/build.gradle
File versionCode content:
        versionCode 7
Done running appcenter-pre-build.sh script

##[section]Finishing: Pre Build Script
##[section]Starting: Gradle Task
```
I've also verified on a physical device loaded with an APK built by App Center.

I didn't have much luck with "Automatically increment version code" App Center feature helping us here. The feature seemed like it was updating the AndroidManifest.xml with the build number **after** the BuildConfig.java was generated. 