### PR TITLE
unselecting other symptom buttons when 'no symptoms today' options is…

### DIFF
--- a/app/src/main/java/org/coepi/android/ui/symptoms/SymptomsViewModel.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/SymptomsViewModel.kt
@@ -63,7 +63,17 @@ class SymptomsViewModel(
         disposables += checkedSymptomTrigger
             .withLatestFrom(selectedSymptomIds)
             .subscribe { (selectedSymptom, selectedIds) ->
-                selectedSymptomIds.onNext(selectedIds.toggle(selectedSymptom.symptom.id))
+                if (selectedSymptom.symptom.id == SymptomId.NONE && !selectedSymptom.isChecked) {
+                    // "No symptoms" selected. Unselect all other symptoms that were selected/highlighted
+                    selectedSymptomIds.onNext(emptySet<SymptomId>().toggle(selectedSymptom.symptom.id))
+                } else if (selectedSymptom.symptom.id == SymptomId.NONE && selectedIds.size == 1) {
+                    // "No symptoms" selected with no other symptoms highlighted. Only toggles NONE
+                    selectedSymptomIds.onNext(selectedIds.toggle(selectedSymptom.symptom.id))
+                } else {
+                    selectedSymptomIds.onNext(
+                        selectedIds.minus(SymptomId.NONE).toggle(selectedSymptom.symptom.id)
+                    )
+                }
             }
 
         disposables += submitTrigger


### PR DESCRIPTION
handles one of the issues mentioned in https://github.com/Co-Epi/app-android/issues/136. 

On the Symptoms Reporting page, you now cannot select the "I dont have any symptoms today" while other symptoms are selected. 