### PR TITLE
Close keyboard after entering text

### DIFF
--- a/app/src/main/java/org/coepi/android/ui/common/KeyboardHider.kt
+++ b/app/src/main/java/org/coepi/android/ui/common/KeyboardHider.kt
@@ -1,0 +1,15 @@
+package org.coepi.android.ui.common
+
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+
+class KeyboardHider {
+    fun hideKeyboard(context: Context, view: View) {
+        val imm: InputMethodManager =
+            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+    }
+
+}

--- a/app/src/main/java/org/coepi/android/ui/symptoms/cough/CoughDurationFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/cough/CoughDurationFragment.kt
@@ -2,7 +2,6 @@ package org.coepi.android.ui.symptoms.cough
 
 
 import android.app.Activity
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/java/org/coepi/android/ui/symptoms/cough/CoughDurationFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/cough/CoughDurationFragment.kt
@@ -1,12 +1,14 @@
 package org.coepi.android.ui.symptoms.cough
 
 
-import androidx.fragment.app.Fragment
+import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import org.coepi.android.databinding.FragmentCoughDurationBinding
+import android.view.inputmethod.InputMethodManager
+import androidx.fragment.app.Fragment
 import org.coepi.android.databinding.FragmentCoughDurationBinding.inflate
 import org.coepi.android.ui.extensions.onBack
 import org.coepi.android.ui.extensions.onTextChanged
@@ -29,4 +31,19 @@ class CoughDurationFragment : Fragment() {
         onBack { viewModel.onBack() }
         toolbar.setNavigationOnClickListener { viewModel.onBackPressed() }
     }.root
+
+    override fun onStop() {
+        hideKeyboardFrom(this.requireContext(),
+            this.requireView())
+        super.onStop()
+    }
+
+    private fun hideKeyboardFrom(
+        context: Context,
+        view: View
+    ) {
+        val imm: InputMethodManager =
+            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/cough/CoughDurationFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/cough/CoughDurationFragment.kt
@@ -33,17 +33,9 @@ class CoughDurationFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        hideKeyboardFrom(this.requireContext(),
-            this.requireView())
-        super.onStop()
-    }
-
-    private fun hideKeyboardFrom(
-        context: Context,
-        view: View
-    ) {
         val imm: InputMethodManager =
-            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view.windowToken, 0)
+            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        super.onStop()
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/cough/CoughDurationFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/cough/CoughDurationFragment.kt
@@ -1,14 +1,12 @@
 package org.coepi.android.ui.symptoms.cough
 
-
-import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
 import org.coepi.android.databinding.FragmentCoughDurationBinding.inflate
+import org.coepi.android.ui.common.KeyboardHider
 import org.coepi.android.ui.extensions.onBack
 import org.coepi.android.ui.extensions.onTextChanged
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -32,9 +30,7 @@ class CoughDurationFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        val imm: InputMethodManager =
-            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        KeyboardHider().hideKeyboard(this.requireContext(), this.requireView())
         super.onStop()
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/earliestsymptom/EarliestSymptomFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/earliestsymptom/EarliestSymptomFragment.kt
@@ -1,14 +1,12 @@
 package org.coepi.android.ui.symptoms.earliestsymptom
 
-
-import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
 import org.coepi.android.databinding.FragmentEarliestSymptomBinding.inflate
+import org.coepi.android.ui.common.KeyboardHider
 import org.coepi.android.ui.extensions.onBack
 import org.coepi.android.ui.extensions.onTextChanged
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -33,9 +31,7 @@ class EarliestSymptomFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        val imm: InputMethodManager =
-            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        KeyboardHider().hideKeyboard(this.requireContext(), this.requireView())
         super.onStop()
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/earliestsymptom/EarliestSymptomFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/earliestsymptom/EarliestSymptomFragment.kt
@@ -34,18 +34,9 @@ class EarliestSymptomFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        hideKeyboardFrom(this.requireContext(),
-            this.requireView())
+        val imm: InputMethodManager =
+            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view?.windowToken, 0)
         super.onStop()
     }
-
-    private fun hideKeyboardFrom(
-        context: Context,
-        view: View
-    ) {
-        val imm: InputMethodManager =
-            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view.windowToken, 0)
-    }
-
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/earliestsymptom/EarliestSymptomFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/earliestsymptom/EarliestSymptomFragment.kt
@@ -1,10 +1,13 @@
 package org.coepi.android.ui.symptoms.earliestsymptom
 
 
+import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
 import org.coepi.android.databinding.FragmentEarliestSymptomBinding.inflate
 import org.coepi.android.ui.extensions.onBack
@@ -29,5 +32,20 @@ class EarliestSymptomFragment : Fragment() {
         onBack { viewModel.onBack() }
         toolbar.setNavigationOnClickListener { viewModel.onBackPressed() }
     }.root
+
+    override fun onStop() {
+        hideKeyboardFrom(this.requireContext(),
+            this.requireView())
+        super.onStop()
+    }
+
+    private fun hideKeyboardFrom(
+        context: Context,
+        view: View
+    ) {
+        val imm: InputMethodManager =
+            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
 
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/earliestsymptom/EarliestSymptomFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/earliestsymptom/EarliestSymptomFragment.kt
@@ -2,7 +2,6 @@ package org.coepi.android.ui.symptoms.earliestsymptom
 
 
 import android.app.Activity
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverDurationFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverDurationFragment.kt
@@ -34,17 +34,9 @@ class FeverDurationFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        hideKeyboardFrom(this.requireContext(),
-            this.requireView())
-        super.onStop()
-    }
-
-    private fun hideKeyboardFrom(
-        context: Context,
-        view: View
-    ) {
         val imm: InputMethodManager =
-            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view.windowToken, 0)
+            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        super.onStop()
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverDurationFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverDurationFragment.kt
@@ -1,11 +1,14 @@
 package org.coepi.android.ui.symptoms.fever
 
 
+import android.app.Activity
+import android.content.Context
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import org.coepi.android.databinding.FragmentFeverDurationBinding
 import org.coepi.android.databinding.FragmentFeverDurationBinding.inflate
 import org.coepi.android.ui.extensions.onBack
@@ -29,4 +32,19 @@ class FeverDurationFragment : Fragment() {
         onBack { viewModel.onBack() }
         toolbar.setNavigationOnClickListener { viewModel.onBackPressed() }
     }.root
+
+    override fun onStop() {
+        hideKeyboardFrom(this.requireContext(),
+            this.requireView())
+        super.onStop()
+    }
+
+    private fun hideKeyboardFrom(
+        context: Context,
+        view: View
+    ) {
+        val imm: InputMethodManager =
+            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverDurationFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverDurationFragment.kt
@@ -2,14 +2,12 @@ package org.coepi.android.ui.symptoms.fever
 
 
 import android.app.Activity
-import android.content.Context
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
-import org.coepi.android.databinding.FragmentFeverDurationBinding
 import org.coepi.android.databinding.FragmentFeverDurationBinding.inflate
 import org.coepi.android.ui.extensions.onBack
 import org.coepi.android.ui.extensions.onTextChanged

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverDurationFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverDurationFragment.kt
@@ -1,14 +1,12 @@
 package org.coepi.android.ui.symptoms.fever
 
-
-import android.app.Activity
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
 import org.coepi.android.databinding.FragmentFeverDurationBinding.inflate
+import org.coepi.android.ui.common.KeyboardHider
 import org.coepi.android.ui.extensions.onBack
 import org.coepi.android.ui.extensions.onTextChanged
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -32,9 +30,7 @@ class FeverDurationFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        val imm: InputMethodManager =
-            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        KeyboardHider().hideKeyboard(this.requireContext(), this.requireView())
         super.onStop()
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverHighestTemperatureFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverHighestTemperatureFragment.kt
@@ -2,7 +2,6 @@ package org.coepi.android.ui.symptoms.fever
 
 
 import android.app.Activity
-import android.content.Context
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverHighestTemperatureFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverHighestTemperatureFragment.kt
@@ -1,14 +1,12 @@
 package org.coepi.android.ui.symptoms.fever
 
-
-import android.app.Activity
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
 import org.coepi.android.databinding.FragmentFeverHighestTemperatureBinding.inflate
+import org.coepi.android.ui.common.KeyboardHider
 import org.coepi.android.ui.extensions.onBack
 import org.coepi.android.ui.extensions.onTextChanged
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -32,9 +30,7 @@ class FeverHighestTemperatureFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        val imm: InputMethodManager =
-            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        KeyboardHider().hideKeyboard(this.requireContext(), this.requireView())
         super.onStop()
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverHighestTemperatureFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverHighestTemperatureFragment.kt
@@ -1,11 +1,14 @@
 package org.coepi.android.ui.symptoms.fever
 
 
+import android.app.Activity
+import android.content.Context
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import org.coepi.android.databinding.FragmentFeverHighestTemperatureBinding.inflate
 import org.coepi.android.ui.extensions.onBack
 import org.coepi.android.ui.extensions.onTextChanged
@@ -28,4 +31,19 @@ class FeverHighestTemperatureFragment : Fragment() {
         onBack { viewModel.onBack() }
         toolbar.setNavigationOnClickListener { viewModel.onBackPressed() }
     }.root
+
+    override fun onStop() {
+        hideKeyboardFrom(this.requireContext(),
+            this.requireView())
+        super.onStop()
+    }
+
+    private fun hideKeyboardFrom(
+        context: Context,
+        view: View
+    ) {
+        val imm: InputMethodManager =
+            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverHighestTemperatureFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverHighestTemperatureFragment.kt
@@ -33,17 +33,9 @@ class FeverHighestTemperatureFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        hideKeyboardFrom(this.requireContext(),
-            this.requireView())
-        super.onStop()
-    }
-
-    private fun hideKeyboardFrom(
-        context: Context,
-        view: View
-    ) {
         val imm: InputMethodManager =
-            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view.windowToken, 0)
+            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        super.onStop()
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverTemperatureSpotFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverTemperatureSpotFragment.kt
@@ -1,13 +1,12 @@
 package org.coepi.android.ui.symptoms.fever
 
-import android.app.Activity
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
 import org.coepi.android.databinding.FragmentFeverTemperatureSpotBinding.inflate
+import org.coepi.android.ui.common.KeyboardHider
 import org.coepi.android.ui.extensions.onBack
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -26,9 +25,7 @@ class FeverTemperatureSpotFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        val imm: InputMethodManager =
-            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        KeyboardHider().hideKeyboard(this.requireContext(), this.requireView())
         super.onStop()
     }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverTemperatureSpotFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverTemperatureSpotFragment.kt
@@ -1,10 +1,13 @@
 package org.coepi.android.ui.symptoms.fever
 
+import android.app.Activity
+import android.content.Context
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import org.coepi.android.databinding.FragmentFeverTemperatureSpotBinding.inflate
 import org.coepi.android.ui.extensions.onBack
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -22,4 +25,19 @@ class FeverTemperatureSpotFragment : Fragment() {
         onBack { viewModel.onBack() }
         toolbar.setNavigationOnClickListener { viewModel.onBackPressed() }
     }.root
+
+    override fun onStop() {
+        hideKeyboardFrom(this.requireContext(),
+            this.requireView())
+        super.onStop()
+    }
+
+    private fun hideKeyboardFrom(
+        context: Context,
+        view: View
+    ) {
+        val imm: InputMethodManager =
+            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
 }

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverTemperatureSpotFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverTemperatureSpotFragment.kt
@@ -1,7 +1,6 @@
 package org.coepi.android.ui.symptoms.fever
 
 import android.app.Activity
-import android.content.Context
 import androidx.fragment.app.Fragment
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverTemperatureSpotFragment.kt
+++ b/app/src/main/java/org/coepi/android/ui/symptoms/fever/FeverTemperatureSpotFragment.kt
@@ -27,17 +27,9 @@ class FeverTemperatureSpotFragment : Fragment() {
     }.root
 
     override fun onStop() {
-        hideKeyboardFrom(this.requireContext(),
-            this.requireView())
-        super.onStop()
-    }
-
-    private fun hideKeyboardFrom(
-        context: Context,
-        view: View
-    ) {
         val imm: InputMethodManager =
-            context.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(view.windowToken, 0)
+            context?.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view?.windowToken, 0)
+        super.onStop()
     }
 }


### PR DESCRIPTION
Hides the keyboard at the end of the fragment life cycle before inflating the next fragment. 