### PR TITLE
Exception to Skip earliest symptom if no symptoms

### DIFF
--- a/app/src/main/java/org/coepi/android/domain/symptomflow/SymptomFlow.kt
+++ b/app/src/main/java/org/coepi/android/domain/symptomflow/SymptomFlow.kt
@@ -58,8 +58,10 @@ class SymptomFlow(private val steps: List<SymptomStep>) {
     }
 }
 private fun toSteps(symptomIds: List<SymptomId>): List<SymptomStep> =
-    symptomIds.flatMap { it.toSteps() }.plus(EARLIEST_SYMPTOM)
-
+    if(!symptomIds.contains(NONE))
+        symptomIds.flatMap { it.toSteps()}.plus(EARLIEST_SYMPTOM)
+    else
+        symptomIds.flatMap { it.toSteps() }
 
 private fun SymptomId.toSteps(): List<SymptomStep> =
     when (this) {


### PR DESCRIPTION
If the user selects No symptoms, it should skip the Earliest Symptom screen and go straight to the Thanks screen. 