### PR TITLE
fix bug when leaving alert details screen fades out and views overlap 

### DIFF
--- a/app/src/main/res/navigation/nav_graph_root.xml
+++ b/app/src/main/res/navigation/nav_graph_root.xml
@@ -64,14 +64,13 @@
     <action
         android:id="@+id/action_global_alerts_details"
         app:destination="@id/alert_details_fragment"
-        app:enterAnim="@android:anim/fade_in"
-        app:popExitAnim="@android:anim/fade_out" />
+        app:enterAnim="@android:anim/fade_in" />
 
     <fragment
         android:id="@+id/alert_info_fragment"
         android:name="org.coepi.android.ui.alertsinfo.AlertsInfoFragment"
         android:label="@string/label_fragment_alerts_info"
-        tools:layout="@layout/fragment_home"></fragment>
+        tools:layout="@layout/fragment_home" />
     <action
         android:id="@+id/action_global_alerts_info"
         app:destination="@id/alert_info_fragment"


### PR DESCRIPTION
https://github.com/Co-Epi/app-android/issues/226

remove fade out animation for alerts details fragment