### PR TITLE
Updated core_version release number 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
 ext {
     koin_version = "2.1.0"
     work_version = "2.3.4"
-    core_version = "0.1.18"
+    core_version = "0.1.19"
 
     binaries_target_dir = "$rootDir/coreBinariesCache/"
     binaries_zip_name = "coreBinaries${core_version}.zip"


### PR DESCRIPTION
Changed to fix building the AAB with new version without the arm64 folder.