### PR TITLE
Remove Unit Tests CI step

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,23 +7,25 @@ on:
     branches: [ develop ]
 
 jobs:
-  test:
-    name: Run Unit Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - name: Unit tests
-        run: ./gradlew test --stacktrace
-      - name: Unit tests results
-        uses: actions/upload-artifact@v2
-        with:
-          name: unit-tests-results
-          path: app/build/reports/tests/testDebugUnitTest/index.html
+  # At the moment all the tests are in the core app.
+  # Reenable if added Unit Tests.
+  #  test:
+  #    name: Run Unit Tests
+  #    runs-on: ubuntu-latest
+  #
+  #    steps:
+  #      - uses: actions/checkout@v2
+  #      - name: set up JDK 1.8
+  #        uses: actions/setup-java@v1
+  #        with:
+  #          java-version: 1.8
+  #      - name: Unit tests
+  #        run: ./gradlew test --stacktrace
+  #      - name: Unit tests results
+  #        uses: actions/upload-artifact@v2
+  #        with:
+  #          name: unit-tests-results
+  #          path: app/build/reports/tests/testDebugUnitTest/index.html
   build:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently all the tests are in the Android core app, so it doesn't make sense to have this step here. It can be re-added if needed.